### PR TITLE
Adding argument parsing as alternative input.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +180,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -255,6 +313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +326,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "http"
@@ -380,16 +450,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "isg_4real"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "inquire",
  "opencv",
  "tokio",
@@ -443,6 +536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,7 +587,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -533,7 +632,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -624,6 +723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +748,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -669,6 +774,30 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -761,6 +890,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,7 +915,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -915,6 +1058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +1086,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -991,7 +1149,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1112,6 +1270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1412,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.68"
+clap = {version = "4.1.6", features = ["derive"]}
 inquire = "0.5.3"
 opencv = "0.75.0"
 tokio = {version = "1.24.2", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ clap = {version = "4.1.6", features = ["derive"]}
 inquire = "0.5.3"
 opencv = "0.75.0"
 tokio = {version = "1.24.2", features = ["full"]}
-# youtube_dl = "0.8.0"
 youtube_dl = { version = "0.8.0", features = ["downloader"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,103 @@
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+/// This encodes which, if any, subcommand was picked.
+/// If none were picked, default to UI selects.
+#[derive(Parser)]
+pub struct Arguments {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+/// This encodes the specific subcommand the user requested: embed, download or dislodge.
+#[derive(Subcommand)]
+pub enum Commands {
+    Embed(EmbedParams),
+    Download(DownloadParams),
+    Dislodge(DislodgeParams),
+}
+
+/// This encodes the specific params for embedding.
+/// All values are optional, and will be substituted in using UI if missing.
+#[derive(Args, Default)]
+pub struct EmbedParams {
+    #[arg(short, long)]
+    /// Path to the file with the data to encode
+    pub in_path: Option<String>,
+
+    /// Preset to use when encoding data.
+    /// More specific encoding options override preset options.
+    #[arg(short, long)]
+    pub preset: Option<EmbedPreset>,
+
+    /// Etching mode
+    #[arg(long)]
+    pub mode: Option<EmbedOutputMode>,
+
+    /// Block size, in pixels per side
+    #[arg(long)]
+    pub block_size: Option<i32>,
+
+    /// Threads to use when encoding
+    #[arg(long)]
+    pub threads: Option<usize>,
+
+    /// Output video FPS
+    #[arg(long)]
+    pub fps: Option<i32>,
+
+    /// Output video resolution.
+    /// Must be one of "144", "240", "360", "480" or "720",
+    /// and if the value provided is none of these,
+    /// defaults to "360".
+    #[arg(long)]
+    pub resolution: Option<String>, // TODO: fix this so it's checked at parse time
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum EmbedPreset {
+    /// Optimal compression resistance
+    Optimal,
+    /// Paranoid compression resistance
+    Paranoid,
+    /// Maximum efficiency
+    MaxEfficiency,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum EmbedOutputMode {
+    /// Uses RGB values and breaks under compression
+    Colored,
+    /// Uses black and white pixels and resists compression
+    Binary,
+}
+
+impl From<EmbedOutputMode> for crate::settings::OutputMode {
+    fn from(value: EmbedOutputMode) -> Self {
+        match value {
+            EmbedOutputMode::Colored => Self::Color,
+            EmbedOutputMode::Binary => Self::Binary,
+        }
+    }
+}
+
+/// This encodes the specific params for downloading.
+/// All values are optional, and will be substituted in using UI if missing.
+#[derive(Args, Default)]
+pub struct DownloadParams {
+    /// Video URL
+    #[arg(short, long)]
+    pub url: Option<String>,
+}
+
+/// This encodes the specific params for dislodging.
+/// All values are optional, and will be substituted in using UI if missing.
+#[derive(Args, Default)]
+pub struct DislodgeParams {
+    /// Path to input video
+    #[arg(short, long)]
+    pub in_path: Option<String>,
+
+    /// Path to file output (including extension)
+    #[arg(short, long)]
+    pub out_path: Option<String>,
+}

--- a/src/embedsource.rs
+++ b/src/embedsource.rs
@@ -1,5 +1,5 @@
 use opencv::core::prelude::*;
-use opencv::core::{Mat, CV_8UC3, Size};
+use opencv::core::{Mat, Size, CV_8UC3};
 
 //Putting width and height here potentially overkill, mostly here for convenience
 //I WANT THAT MAX PERFORMANCE
@@ -31,9 +31,9 @@ impl EmbedSource {
 
             EmbedSource {
                 image,
-                size, 
+                size,
                 frame_size,
-                actual_size
+                actual_size,
             }
         }
     }
@@ -50,9 +50,9 @@ impl EmbedSource {
 
         EmbedSource {
             image,
-            size, 
+            size,
             frame_size,
-            actual_size
+            actual_size,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
-mod ui;
-mod etcher;
-mod settings;
+mod args;
 mod embedsource;
+mod etcher;
+mod run_tasks;
+mod settings;
 mod timer;
+mod ui;
 
-use settings::{Data, Settings};
+use clap::Parser;
+
+use crate::args::Arguments;
 
 //Make RGB a struct
 //Make it calculate how much data is jammed in 1 frame for user
@@ -15,12 +19,17 @@ async fn main() -> anyhow::Result<()> {
     println!("\nHow to use:");
     println!("1. Zip all the files you will be uploading");
     println!("2. Use the embed option on the archive (THE VIDEO WILL BE SEVERAL TIMES LARGER THAN THE FILE, 4x in case of optimal compression resistance preset)");
-    println!("3. Upload the video to your YouTube channel. You probably want to keep it up as unlisted");
+    println!(
+        "3. Upload the video to your YouTube channel. You probably want to keep it up as unlisted"
+    );
     println!("4. Use the download option to get the video back");
     println!("5. Use the dislodge option to get your files back from the downloaded video");
     println!("6. PROFIT\n");
 
-    ui::summon_gooey().await?;
+    let mut args = Arguments::parse();
+    let new_command = ui::enrich_arguments(args.command).await?;
+    args.command = Some(new_command);
 
-    return Ok(());
+    run_tasks::run_by_arguments(args).await?;
+    Ok(())
 }

--- a/src/run_tasks.rs
+++ b/src/run_tasks.rs
@@ -1,0 +1,16 @@
+use crate::args::Arguments;
+
+pub mod dislodge;
+pub mod download;
+pub mod embed;
+
+pub async fn run_by_arguments(args: Arguments) -> anyhow::Result<()> {
+    match args
+        .command
+        .expect("Command was not provided by the time run_by_arguments is used")
+    {
+        crate::args::Commands::Embed(args) => embed::run_embed(args).await,
+        crate::args::Commands::Download(args) => download::run_download(args).await,
+        crate::args::Commands::Dislodge(args) => dislodge::run_dislodge(args).await,
+    }
+}

--- a/src/run_tasks/dislodge.rs
+++ b/src/run_tasks/dislodge.rs
@@ -1,0 +1,10 @@
+use crate::{args::DislodgeParams, etcher};
+
+pub async fn run_dislodge(args: DislodgeParams) -> anyhow::Result<()> {
+    let out_data = etcher::read(&args.in_path.expect("no in path at run_dislodge"), 1)?;
+    etcher::write_bytes(
+        &args.out_path.expect("no out path at run_dislodge"),
+        out_data,
+    )?;
+    Ok(())
+}

--- a/src/run_tasks/download.rs
+++ b/src/run_tasks/download.rs
@@ -1,0 +1,22 @@
+use youtube_dl::{download_yt_dlp, YoutubeDl};
+
+use crate::args::DownloadParams;
+
+pub async fn run_download(args: DownloadParams) -> anyhow::Result<()> {
+    let yt_dlp_path = download_yt_dlp(".").await?;
+
+    println!("Starting the download, there is no progress bar");
+    let output = YoutubeDl::new(&args.url.expect("No URL in params when run_download"))
+        .youtube_dl_path(yt_dlp_path)
+        .format("best")
+        .download(true)
+        .run_async()
+        .await?;
+
+    let _video = output.into_single_video().unwrap();
+    // let title = video.title;
+
+    println!("Video downloaded succesfully");
+
+    return Ok(());
+}

--- a/src/run_tasks/embed.rs
+++ b/src/run_tasks/embed.rs
@@ -1,0 +1,95 @@
+use crate::{
+    args::{EmbedParams, EmbedPreset},
+    etcher,
+    settings::{Data, OutputMode, Settings},
+};
+
+pub async fn run_embed(args: EmbedParams) -> anyhow::Result<()> {
+    //Should use enums
+    let mut settings = Settings::default();
+    let mut output_mode = OutputMode::Binary;
+
+    match args.preset {
+        Some(EmbedPreset::MaxEfficiency) => {
+            output_mode = OutputMode::Color;
+            settings.size = 1;
+            settings.threads = 8;
+            settings.fps = 10.0;
+            settings.width = 256;
+            settings.height = 144;
+        }
+        Some(EmbedPreset::Optimal) => {
+            output_mode = OutputMode::Binary;
+            settings.size = 2;
+            settings.threads = 8;
+            settings.fps = 10.0;
+            settings.width = 1280;
+            settings.height = 720;
+        }
+        Some(EmbedPreset::Paranoid) => {
+            output_mode = OutputMode::Binary;
+
+            settings.size = 4;
+            settings.threads = 8;
+            settings.fps = 10.0;
+            settings.width = 1280;
+            settings.height = 720;
+        }
+        _ => (),
+    }
+
+    // If none of the presets were picked,
+    // then all the parameters are included in the args,
+    // so it is safe to gather them from the args now
+
+    if settings.width == 0 || settings.height == 0 {
+        if args.resolution.is_none() {
+            settings.width = 640;
+            settings.height = 360;
+        } else {
+            let (width, height) = match args.resolution.unwrap().as_str() {
+                "144p" => (256, 144),
+                "240p" => (426, 240),
+                "360p" => (640, 360),
+                "480p" => (854, 480),
+                "720p" => (1280, 720),
+                _ => (640, 360),
+            };
+            settings.width = width;
+            settings.height = height;
+        }
+    };
+
+    if let Some(mode) = args.mode {
+        output_mode = mode.into();
+    }
+    if let Some(bs) = args.block_size {
+        settings.size = bs;
+    }
+    if let Some(threads) = args.threads {
+        settings.threads = threads;
+    }
+    if let Some(fps) = args.fps {
+        settings.fps = fps.into();
+    }
+
+    match output_mode {
+        OutputMode::Color => {
+            let bytes = etcher::rip_bytes(&args.in_path.expect("no path in arguments"))?;
+
+            let data = Data::from_color(bytes);
+
+            etcher::etch("output.avi", data, settings)?;
+        }
+        OutputMode::Binary => {
+            let bytes = etcher::rip_bytes(&args.in_path.expect("no path in arguments"))?;
+            let binary = etcher::rip_binary(bytes)?;
+
+            let data = Data::from_binary(binary);
+
+            etcher::etch("output.avi", data, settings)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -12,11 +12,12 @@ pub struct Data {
 
 //Get rid of possible empty spaces
 impl Data {
+    #[allow(dead_code)]
     pub fn new_out_mode(out_mode: OutputMode) -> Data {
         Data {
             bytes: Vec::new(),
             binary: Vec::new(),
-            out_mode
+            out_mode,
         }
     }
 
@@ -34,10 +35,10 @@ impl Data {
             binary: Vec::new(),
             out_mode: OutputMode::Color,
         }
-    } 
+    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Settings {
     pub size: i32,
     pub threads: usize,
@@ -47,14 +48,13 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn new(size: i32, threads: usize, fps: i32, width: i32, height: i32) 
-            -> Settings {
+    pub fn new(size: i32, threads: usize, fps: i32, width: i32, height: i32) -> Settings {
         Settings {
             size,
             threads,
             fps: fps as f64,
-            height, 
-            width
+            height,
+            width,
         }
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,4 +1,3 @@
-use std::time::{self, Duration};
 use std::time::Instant;
 
 pub struct Timer {
@@ -16,16 +15,12 @@ impl Drop for Timer {
         } else {
             println!("{} ended in {}ms", self.title, millis);
         }
-        
     }
 }
 
 impl Timer {
     pub fn new(title: &'static str) -> Timer {
         let start = Instant::now();
-        Timer {
-            title,
-            time: start,
-        }
+        Timer { title, time: start }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,205 +1,193 @@
 use anyhow;
-use inquire::{
-    CustomType, min_length, Confirm, MultiSelect, Password, Select, Text,
-};
-use youtube_dl::{download_yt_dlp, YoutubeDl};
+#[allow(unused_imports)]
+use inquire::{min_length, Confirm, CustomType, MultiSelect, Password, Select, Text};
 
-use crate::settings::{Settings, OutputMode, Data};
-use crate::etcher;
+use crate::args::{Commands, DislodgeParams, DownloadParams, EmbedParams};
 
-pub async fn summon_gooey() -> anyhow::Result<()> {
-    let options = vec![
-        "Embed",
-        "Download",
-        "Dislodge"
-    ];
+pub async fn enrich_arguments(args: Option<Commands>) -> anyhow::Result<Commands> {
+    // If we already know which mode we would run, defer to that mode.
+    // Else, get the mode from the user, and defer to the mode.
+    Ok(match args {
+        Some(Commands::Embed(embed_args)) => {
+            Commands::Embed(enrich_embed_params(embed_args).await?)
+        }
+        Some(Commands::Download(download_args)) => {
+            Commands::Download(enrich_download_params(download_args).await?)
+        }
+        Some(Commands::Dislodge(dislodge_args)) => {
+            Commands::Dislodge(enrich_dislodge_params(dislodge_args).await?)
+        }
+        None => {
+            let options = vec!["Embed", "Download", "Dislodge"];
 
-    let modes = Select::new("Pick what you want to do with the program", options)
-        .with_help_message("Embed: Create a video from files,\n Download: Download files stored on YouTube,\n Dislodge: Return files from an embedded video")
-        .prompt()
-        .unwrap();
+            let modes = Select::new("Pick what you want to do with the program", options)
+                .with_help_message("Embed: Create a video from files,\n Download: Download files stored on YouTube,\n Dislodge: Return files from an embedded video")
+                .prompt()
+                .unwrap();
 
-    match modes {
-        "Embed" => return embed_path(),
-        "Download" => return download_path().await,
-        "Dislodge" => return dislodge_path(),
-        _ => {panic!("Something weird happened when selecting modes");}
-    }
+            match modes {
+                "Embed" => Commands::Embed(enrich_embed_params(EmbedParams::default()).await?),
+                "Download" => {
+                    Commands::Download(enrich_download_params(DownloadParams::default()).await?)
+                }
+                "Dislodge" => {
+                    Commands::Dislodge(enrich_dislodge_params(DislodgeParams::default()).await?)
+                }
+                _ => unreachable!(),
+            }
+        }
+    })
 }
 
-
-fn embed_path()  -> anyhow::Result<()> {
-
-    //Should use enums
-    let presets = vec![
-        "Optimal compression resistance",
-        "Paranoid compression resistance",
-        "Maximum efficiency",
-        "Custom"
-    ];
-
-    let out_modes = vec![
-        "Colored",
-        "B/W (Binary)",
-    ];
-
-    let resolutions = vec![
-        "144p",
-        "240p",
-        "360p",
-        "480p",
-        "720p",
-    ];
-
-    let path = Text::new("What is the path to your file ?")
-    .with_default("src/tests/test.txt")
-    .prompt().unwrap();
-
-    let preset = Select::new("You can use one of the existing presets or custom settings", presets.clone())
-        .with_help_message("Any amount of compression on Maximum Efficiency will corrupt all your hopes and dreams")
-        .prompt()
-        .unwrap();
-
-    match preset {
-        "Maximum efficiency" => {
-            let bytes = etcher::rip_bytes(&path)?;
-
-            let data = Data::from_color(bytes);
-            // let settings = Settings::new(1, 8, 1, 640, 360);
-            let settings = Settings::new(1, 8, 10, 256, 144);
-
-            etcher::etch("output.avi", data, settings)?;
-
-            return Ok(());
-        },
-        "Optimal compression resistance" => {
-            let bytes = etcher::rip_bytes(&path)?;
-            let binary = etcher::rip_binary(bytes)?;
-
-            let data = Data::from_binary(binary);
-            let settings = Settings::new(2, 8, 10, 1280, 720);
-
-            etcher::etch("output.avi", data, settings)?;
-
-            return Ok(());
-        },
-        "Paranoid compression resistance" => {
-            let bytes = etcher::rip_bytes(&path)?;
-            let binary = etcher::rip_binary(bytes)?;
-
-            let data = Data::from_binary(binary);
-            let settings = Settings::new(4, 8, 10, 1280, 720);
-
-            etcher::etch("output.avi", data, settings)?;
-
-            return Ok(());
-        },
-        _ => (),
+async fn enrich_embed_params(mut args: EmbedParams) -> anyhow::Result<EmbedParams> {
+    if args.in_path.is_none() {
+        let path = Text::new("What is the path to your file ?")
+            .with_default("src/tests/test.txt")
+            .prompt()
+            .unwrap();
+        args.in_path = Some(path);
     }
 
-    let out_mode = Select::new("Pick how data will be embedded", out_modes.clone())
-        .with_help_message("Colored mode is useless if the video undergoes compression at any point, B/W survives compression")
-        .prompt()
-        .unwrap();
+    // If any of the advanced options is set,
+    // then ask for the remaining advanced options.
+    // If none are set, ask for a preset first, and if custom is selected,
+    // then fall through to the advanced options.
+    // This must be after all the other options were parsed,
+    // because if preset is set, this returns.
 
-    println!("\nI coudln't figure out a weird bug that happens if you set the size to something that isn't a factor of the height");
-    println!("If you don't want the files you put in to come out as the audio/visual equivalent of a pipe bomb, account for the above bug\n");
+    if args.mode.is_none()
+        && args.block_size.is_none()
+        && args.threads.is_none()
+        && args.fps.is_none()
+        && args.resolution.is_none()
+    {
+        let presets = vec![
+            "Optimal compression resistance",
+            "Paranoid compression resistance",
+            "Maximum efficiency",
+            "Custom",
+        ];
+        let preset = Select::new("You can use one of the existing presets or custom settings", presets.clone())
+            .with_help_message("Any amount of compression on Maximum Efficiency will corrupt all your hopes and dreams")
+            .prompt()
+            .unwrap();
 
-    let size = CustomType::<i32>::new("What size should the blocks be ?")
-        .with_error_message("Please type a valid number")
-        .with_help_message("Bigger blocks are more resistant to compression, I recommend 2-5.")
-        .with_default(2)
-        .prompt()?;
-
-    let threads = CustomType::<usize>::new("How many threads to dedicate for processing ?")
-        .with_error_message("Please type a valid number")
-        .with_help_message("The more threads, the merrier")
-        .with_default(8)
-        .prompt()?;
-
-    let out_mode = match out_mode {
-        "Colored" => OutputMode::Color,
-        "B/W (Binary)" => OutputMode::Binary,
-        _ => {panic!("AAAAAAAAAAAAAAAA")},
-    };
-
-    let fps = CustomType::<i32>::new("What fps should the video be at ?")
-        .with_error_message("Please type a valid number")
-        .with_help_message("Decreasing fps may decrease chance of compression. ~10fps works")
-        .with_default(30)
-        .prompt()
-        .expect("Invalid fps");
-
-    //Check if higher resolution runs faster
-    let resolution = Select::new("Pick a resolution", resolutions)
-        .with_help_message("I recommend 720p as the resolution won't affect compression")
-        .prompt()
-        .unwrap();
-
-    let (width, height) = match resolution {
-        "144p" => (256, 144),
-        "240p" => (426, 240),
-        "360p" => (640, 360),
-        "480p" => (854, 480),
-        "720p" => (1280, 720),
-        _ => (640, 360),
-    };
-
-    match out_mode {
-        OutputMode::Color => {
-            let bytes = etcher::rip_bytes(&path)?;
-
-            let data = Data::from_color(bytes);
-            let settings = Settings::new(size, threads, fps, width, height);
-
-            etcher::etch("output.avi", data, settings)?;
-        },
-        OutputMode::Binary => {
-            let bytes = etcher::rip_bytes(&path)?;
-            let binary = etcher::rip_binary(bytes)?;
-
-            let data = Data::from_binary(binary);
-            let settings = Settings::new(size, threads, fps, width, height);
-
-            etcher::etch("output.avi", data, settings)?;
-        },
+        match preset {
+            "Maximum efficiency" => {
+                args.preset = Some(crate::args::EmbedPreset::MaxEfficiency);
+                return Ok(args);
+            }
+            "Optimal compression resistance" => {
+                args.preset = Some(crate::args::EmbedPreset::Optimal);
+                return Ok(args);
+            }
+            "Paranoid compression resistance" => {
+                args.preset = Some(crate::args::EmbedPreset::Paranoid);
+                return Ok(args);
+            }
+            _ => (),
+        }
     }
 
-    return Ok(());
+    // Now, either custom is selected or some CLI arguments are set.
+    // Ask advanced questions now.
+
+    if args.mode.is_none() {
+        let out_modes = vec!["Colored", "B/W (Binary)"];
+        let out_mode = Select::new("Pick how data will be embedded", out_modes.clone())
+            .with_help_message("Colored mode is useless if the video undergoes compression at any point, B/W survives compression")
+            .prompt()
+            .unwrap();
+        args.mode = Some(match out_mode {
+            "Colored" => crate::args::EmbedOutputMode::Colored,
+            "B/W (Binary)" => crate::args::EmbedOutputMode::Binary,
+            _ => unreachable!(),
+        });
+    }
+
+    if args.block_size.is_none() {
+        let size = CustomType::<i32>::new("What size should the blocks be ?")
+            .with_error_message("Please type a valid number")
+            .with_help_message("Bigger blocks are more resistant to compression, I recommend 2-5.")
+            .with_default(2)
+            .prompt()?;
+        args.block_size = Some(size);
+    }
+
+    if args.threads.is_none() {
+        let threads = CustomType::<usize>::new("How many threads to dedicate for processing ?")
+            .with_error_message("Please type a valid number")
+            .with_help_message("The more threads, the merrier")
+            .with_default(8)
+            .prompt()?;
+        args.threads = Some(threads);
+    }
+
+    if args.fps.is_none() {
+        let fps = CustomType::<i32>::new("What fps should the video be at ?")
+            .with_error_message("Please type a valid number")
+            .with_help_message("Decreasing fps may decrease chance of compression. ~10fps works")
+            .with_default(30)
+            .prompt()
+            .expect("Invalid fps");
+        args.fps = Some(fps);
+    }
+
+    let resolutions = vec!["144p", "240p", "360p", "480p", "720p"];
+
+    if args.resolution.is_none() {
+        //Check if higher resolution runs faster
+        let resolution = Select::new("Pick a resolution", resolutions)
+            .with_help_message("I recommend 720p as the resolution won't affect compression")
+            .prompt()
+            .unwrap();
+        args.resolution = Some(resolution.to_string());
+    }
+    // Now, make sure that the resolution string does not contain a "p".
+    // The unwrap is safe because it's being run either when we skipped the if,
+    // or after executing it, and both leave resolution as Some
+    args.resolution = Some(
+        match args.resolution.unwrap().as_str() {
+            "144p" => "144",
+            "240p" => "240",
+            "360p" => "360",
+            "480p" => "480",
+            "720p" => "720",
+            _ => "360",
+        }
+        .to_string(),
+    );
+
+    Ok(args)
 }
 
-async fn download_path()  -> anyhow::Result<()> {
-    //
-    let url = Text::new("What is the url to the video ?")
-        .prompt().unwrap();
-
-    let yt_dlp_path = download_yt_dlp(".").await?;
-
-    println!("Starting the download, there is no progress bar");
-    let output = YoutubeDl::new(&url)
-        .youtube_dl_path(yt_dlp_path)
-        .format("best")
-        .download(true)
-        .run_async()
-        .await?;
-
-    let video = output.into_single_video().unwrap();
-    let title = video.title;
-
-    println!("Video downloaded succesfully");
-
-    return Ok(());
+async fn enrich_download_params(mut args: DownloadParams) -> anyhow::Result<DownloadParams> {
+    if args.url.is_none() {
+        let url = Text::new("What is the url to the video ?")
+            .prompt()
+            .unwrap();
+        args.url = Some(url);
+    }
+    Ok(args)
 }
 
 //TEMPORARY DEFAULTS
-fn dislodge_path()  -> anyhow::Result<()> {
-    let in_path = Text::new("What is the path to your video ?")
-        .with_default("output.avi")
-        .prompt().unwrap();
+async fn enrich_dislodge_params(mut args: DislodgeParams) -> anyhow::Result<DislodgeParams> {
+    if args.in_path.is_none() {
+        let in_path = Text::new("What is the path to your video ?")
+            .with_default("output.avi")
+            .prompt()
+            .unwrap();
+        args.in_path = Some(in_path);
+    }
 
-    let out_path = Text::new("Where should the output go ?")
-        .with_help_message("Please include name of file and extension")
-        .prompt().unwrap();
+    if args.out_path.is_none() {
+        let out_path = Text::new("Where should the output go ?")
+            .with_help_message("Please include name of file and extension")
+            .prompt()
+            .unwrap();
+        args.out_path = Some(out_path);
+    }
 
     // let threads = CustomType::<usize>::new("How many threads to dedicate for processing ?")
     //     .with_error_message("Please type a valid number")
@@ -207,8 +195,5 @@ fn dislodge_path()  -> anyhow::Result<()> {
     //     .with_default(8)
     //     .prompt()?;
 
-    let out_data = etcher::read(&in_path, 1)?;
-    etcher::write_bytes(&out_path, out_data)?;
-
-    return Ok(());
+    Ok(args)
 }


### PR DESCRIPTION
This refactors the execution into two phases.
First, we collect the input on what we need to do, and then we take the complete set of instructions and execute them.

Input can now come from the command line using `clap`, in addition to interactively using `inquire`.
If a value is set with `clap`, it is not asked again with `inquire`.

This allows for semi-scripting usage, which is helpful for automated setups like CI.