### PR TITLE
Create Rust build workflow

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,0 +1,36 @@
+name: Rust continuous build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Cache Rust dependencies
+      id: cache-deps
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-rust-deps
+      with:
+        path: target
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Build
+      run: cargo build --verbose
+    - name: Upload built version
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: isg_4real_debug_linux_x86_64
+        path: target/debug/isg_4real


### PR DESCRIPTION
This adds a basic GitHub Actions workflow that builds the executable and uploads it as an artifact, which can then be used by other CI/CD workflows.

I haven't tested that this works, and I'm not very experienced with GitHub Actions, so this might require some tweaks to work properly.