### PR TITLE
chore(src/etcher.rs): ✏️ Fix typo in println  "succesfully" -> "successfully"

### DIFF
--- a/src/embedsource.rs
+++ b/src/embedsource.rs
@@ -33,7 +33,7 @@ impl EmbedSource {
         let height = image.rows();
         let frame_size = Size::new(width, height);
 
-        //Some malovelent spirit breaks data when height is not divisible
+        //Some malevolent spirit breaks data when height is not divisible
         if height % size != 0 {
             return Err("Image size is not a multiple of the embedding size".to_string());
         }

--- a/src/etcher.rs
+++ b/src/etcher.rs
@@ -541,7 +541,7 @@ pub fn etch(path: &str, data: Data, settings: Settings) -> anyhow::Result<()> {
     }
     video.release()?;
 
-    println!("Video embedded succesfully at {}", path);
+    println!("Video embedded successfully at {}", path);
 
     return Ok(());
 }


### PR DESCRIPTION
For a better user experience, we must make sure the CLI has correct spelling.