### PR TITLE
Add codespace config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+ARG VARIANT="1"
+FROM mcr.microsoft.com/devcontainers/rust:${VARIANT}
+
+RUN apt update && apt install -y ffmpeg libopencv-dev clang libclang-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "Rust",
+    "build": {
+        "context": "..",
+        "dockerfile": "Dockerfile",
+        "args": {
+            "VARIANT": "1",
+            "NODE_VERSION": "none"
+        }
+    },
+    "postCreateCommand": "cargo build",
+    "remoteUser": "vscode"
+}


### PR DESCRIPTION
This adds configuration allowing a potential contributor to get set up in GitHub Codespaces, so that they can instantly consume their monthly CPU usage :tada:
(Not a criticism of this project BTW. Any significant Rust project seems to have massive CPU usage when compiling.)

## What this PR does

When initially building the container, the latest release of the Rust 1 image will be used ([more details](https://github.com/devcontainers/images/tree/main/src/rust)), and dependencies required to build and run isg will also be installed.

After the container is created, `cargo build` is run. This can potentially be removed, but triggering a build immediately can lead to an improved developer experience as the long process of updating the crates.io index and compiling starts in the background while the developer codes.

FYI I ran into https://github.com/DvorakDwarf/Infinite-Storage-Glitch/issues/32 in the codespace. Let me know if any changes to the dev environment can resolve this issue, and I'll add it to the devcontainer setup.