### PR TITLE
Fix issue 62 and issue 61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /test2.mp4
 /output.zip
 /output.png
+/cargo_home/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +70,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
 
 [[package]]
 name = "clang"
@@ -121,6 +145,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +193,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -405,6 +483,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +584,7 @@ name = "isg_4real"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "inquire",
  "opencv",
@@ -536,6 +639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,7 +698,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
 
@@ -615,6 +727,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -925,6 +1047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "security-framework"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1246,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1432,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ inquire = "0.5.3"
 opencv = "0.75.0"
 tokio = {version = "1.24.2", features = ["full"]}
 youtube_dl = { version = "0.8.0", features = ["downloader"] }
+chrono = "0.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get install -y ffmpeg
 RUN apt-get install -y build-essential
 RUN apt-get install -y libssl-dev
 RUN apt-get install -y clang libclang-dev
+RUN apt-get install -y yt-dlp 
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -19,5 +20,9 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Set the working directory 
 WORKDIR /home/Infinite-Storage-Glitch
+
+# Set cargo home to a folder in the working directory this will make rebuild 
+# faster as it allows the cargo cache to be saved between docker runs. 
+ENV CARGO_HOME=/home/Infinite-Storage-Glitch/cargo_home
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get install -y ffmpeg
 RUN apt-get install -y build-essential
 RUN apt-get install -y libssl-dev
 RUN apt-get install -y clang libclang-dev
-RUN apt-get install -y yt-dlp 
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ That's it. You will find the executable in the `target/release` directory.
 
 ℹ️ **Please Note:** The binary will be a linux executable, so you will need to run it in a linux environment.
 If you do not have a linux environment, you can use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) 
-or run it using the docker container called `isg` we just built:
+or run it using the docker container called `isg` we just built **using a Linux shell or PowerShell**:
 
 ```bash
 docker run -it --rm -v ${PWD}:/home/Infinite-Storage-Glitch isg ./target/release/isg_4real
 ```
+
+**Note:** If you are using `cmd` on Windows, you will need to use `%cd%` instead of `${PWD}`.
 
 How to use
 -------------

--- a/src/run_tasks/download.rs
+++ b/src/run_tasks/download.rs
@@ -1,22 +1,42 @@
-use youtube_dl::{download_yt_dlp, YoutubeDl};
+use youtube_dl::{download_yt_dlp};
+use std::process::Command;
 
 use crate::args::DownloadParams;
 
 pub async fn run_download(args: DownloadParams) -> anyhow::Result<()> {
     let yt_dlp_path = download_yt_dlp(".").await?;
+    
+    let url = args.url.expect("No URL in params when run_download");
+    
+    // check if the yt_dlp_path exists
+    if !yt_dlp_path.exists() {
+        println!("yt-dlp not found");
+        return Ok(());
+    }
+    
+    // Output path for the video has the format: `downloaded_{timestamp}.mp4`
+    let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S");
+    let download_path = format!("downloaded_{}.mp4", timestamp);
 
+    // Use the yt-dlp binary to download the video: `yt-dlp -f mp4 -o video.mp4 {url}`
     println!("Starting the download, there is no progress bar");
-    let output = YoutubeDl::new(&args.url.expect("No URL in params when run_download"))
-        .youtube_dl_path(yt_dlp_path)
-        .format("best")
-        .download(true)
-        .run_async()
-        .await?;
+    let output = Command::new(yt_dlp_path)
+        .arg("-f")  // format
+        .arg("mp4") // mp4
+        .arg("-o")  // output
+        .arg(download_path.clone()) // output path
+        .arg(url)  // url to download from
+        .output()
+        .expect("Failed to execute command");
 
-    let _video = output.into_single_video().unwrap();
-    // let title = video.title;
-
-    println!("Video downloaded successfully");
+    // check the output of the command
+    if output.status.success() {
+        println!("Video downloaded successfully");
+        println!("Output path: {}", std::fs::canonicalize(download_path).unwrap().display());
+    } else {
+        println!("Video download failed");
+        println!("Error: {}", String::from_utf8_lossy(&output.stderr));
+    }
 
     return Ok(());
 }


### PR DESCRIPTION
Issue #62 reports problems downloading video files from YouTube. 

I think this problem comes from the [youtube_dl](https://docs.rs/youtube_dl/latest/youtube_dl/) crate although I did not prove it. What I have found however is that the `yt-dlp` binary downloaded works just fine. So I decided to invoke it directly in the rust code instead of relying on the code in the youtube_dl crate. 

Issue #61 reports a problem with the documentation. 

So I updated the README.md file with the hint to help avoid this pitfall. 